### PR TITLE
Fix: Invoke buildUI() in content.js

### DIFF
--- a/content.js
+++ b/content.js
@@ -1199,3 +1199,4 @@ function capturarEPreencherDadosDoContato() {
 // The block of code that adjusted old buttons (`iconeCRM`, `iconeCadastro`, etc.)
 // is also removed by this change as it's no longer needed.
 
+buildUI();


### PR DESCRIPTION
The buildUI() function, responsible for creating and appending all HTML elements of the extension to the document body, was defined but not explicitly called in the global scope of content.js.

This commit adds the `buildUI();` call at the end of content.js, ensuring that the function is executed as soon as the script is loaded, allowing the extension's user interface to be built correctly.